### PR TITLE
Cannonicalize imports.

### DIFF
--- a/console_test.go
+++ b/console_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"strings"
 
-	. "github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 type ConsoleLogSuite struct {

--- a/log_test.go
+++ b/log_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	. "github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 func TestModel(t *testing.T) { TestingT(t) }

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"log/syslog"
 
-	. "github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
 )
 
 type SysLogSuite struct {


### PR DESCRIPTION
These test code import paths looked specific to @klizhentas
workstation 5 years ago. This commit updates them to point to the
cannonical path of the package and lets $GOPATH sort out the rest.

Resolves #3.

Testing Done:
```
walt@work:~/git/log$ go test                      
# _/home/walt/git/log
package _/home/walt/git/log (test)
	imports github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1: cannot find package "github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1" in any of:
	/usr/local/go/src/github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1 (from $GOROOT)
	/home/walt/go/src/github.com/gravitational/teleport/Godeps/_workspace/src/gopkg.in/check.v1 (from $GOPATH)
FAIL	_/home/walt/git/log [setup failed]
walt@work:~/git/log$ git checkout walt/fix-imports                                                                                                                                        [1]
Switched to branch 'walt/fix-imports'
walt@work:~/git/log$ go test
OK: 22 passed
PASS
ok  	_/home/walt/git/log	0.007s
``` 